### PR TITLE
Mute gvfs-trash error messages

### DIFF
--- a/common.lua
+++ b/common.lua
@@ -318,7 +318,7 @@ local function installAddonFile(addon, file)
 		print("\tInstalling folder: " .. dir)
 		table.insert(folders, dir)
 		if lfs.attributes(string.format("%s/%s", BASEDIR, dir)) then
-			os.execute(string.format("gvfs-trash '%s/%s'", BASEDIR, dir))
+			os.execute(string.format("gvfs-trash '%s/%s' 2>/dev/null", BASEDIR, dir))
 		end
 		os.execute(string.format("mv '%s' '%s'", path, BASEDIR))
 		os.execute(string.format("chmod -R 777 '%s/%s'", BASEDIR, dir))


### PR DESCRIPTION
It may nag about itself being deprecated.

As discussed in #8 